### PR TITLE
Replaced ; with && to fix Windows compatibility

### DIFF
--- a/packages/character-network/package.json
+++ b/packages/character-network/package.json
@@ -10,7 +10,7 @@
   ],
   "type": "commonjs",
   "scripts": {
-    "build": "rimraf ./dist; node ./build.js --build",
+    "build": "rimraf ./dist && node ./build.js --build",
     "iterate": "node ./build.js --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./src/**/*.{ts,}\" --max-warnings 0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "/src"
   ],
   "scripts": {
-    "build": "rimraf ./dist; node ./build.js --build",
+    "build": "rimraf ./dist && node ./build.js --build",
     "iterate": "node ./build.js --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./src/**/*.{ts,}\" --max-warnings 0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   "main": "./src/index.js",
   "scripts": {
     "iterate": "nodemon",
-    "build": "rimraf ./dist; node build.mjs",
+    "build": "rimraf ./dist && node build.mjs",
     "start": "NODE_ENV=production node dist/index.js",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./src/**/*.{ts,}\" --max-warnings 0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "iterate": "npm run build -- --serve --watch",
-    "build": "rimraf ./dist; env-cmd --silent node build.mjs",
+    "build": "rimraf ./dist && env-cmd --silent node build.mjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./src/**/*.{ts,tsx}\" --max-warnings 0",
     "lint:fix": "eslint \"./src/**/*.{ts,tsx}\" --fix"


### PR DESCRIPTION
**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix: `;` does not work to separate commands on windows. Replaced with `&&` in `build` scripts.

