### PR TITLE
Fix GLB collision geometry parsing

### DIFF
--- a/packages/core/src/collisions/CollisionsManager.ts
+++ b/packages/core/src/collisions/CollisionsManager.ts
@@ -37,9 +37,19 @@ export class CollisionsManager {
         const mesh = child as Mesh;
         mesh.localToWorld(new Vector3());
         mesh.updateMatrixWorld();
-        const geometry = mesh.geometry.clone();
-        geometry.applyMatrix4(mesh.matrixWorld);
-        geometries.push(geometry);
+        const clonedGeometry = mesh.geometry.clone();
+        clonedGeometry.applyMatrix4(mesh.matrixWorld);
+
+        for (const key in clonedGeometry.attributes) {
+          if (key !== "position") {
+            clonedGeometry.deleteAttribute(key);
+          }
+        }
+        if (clonedGeometry.index) {
+          geometries.push(clonedGeometry.toNonIndexed());
+        } else {
+          geometries.push(clonedGeometry);
+        }
       }
     });
     const newBufferGeometry = BufferGeometryUtils.mergeGeometries(geometries);


### PR DESCRIPTION
This PR fixes an issue when using GLB files that include attributes that the collision geometry parsing fails to interpret.

The solution in this PR is to strip all attributes other than vertex position from the cloned geometry.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
