### PR TITLE
Support for MML Collision Events (with MML v0.3) (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,45 +1140,158 @@
         "node": ">=10"
       }
     },
-    "node_modules/@mml-io/networked-dom-document": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-document/-/networked-dom-document-0.2.0.tgz",
-      "integrity": "sha512-IzRA8r7k3hOYclHk2WK9BR6sN2HBr8BWY4Tmxg8jKBMyvKtlDhwCCb03EG4BrEc8OEFEdTcmZ5e71ecx+loxuw==",
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
       "dependencies": {
-        "@mml-io/networked-dom-protocol": "^0.2.0",
-        "@mml-io/observable-dom-common": "^0.2.0",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mml-io/networked-dom-document": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-document/-/networked-dom-document-0.3.0.tgz",
+      "integrity": "sha512-9bi9QZD+SQamzNabUoLWe0bcEMd5zFBb+39nKZb5pnBbGr2SiD5Chb1/YEHF3ltuZ0ht4Jasy/f3ghiT8H80Rw==",
+      "dependencies": {
+        "@mml-io/networked-dom-protocol": "^0.3.0",
+        "@mml-io/observable-dom-common": "^0.3.0",
         "rfc6902": "git+https://github.com/marcuslongmuir/rfc6902.git#7b81b044d7c2cd36f34f9f30d106e7f5db8a0589"
       }
     },
     "node_modules/@mml-io/networked-dom-protocol": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-protocol/-/networked-dom-protocol-0.2.0.tgz",
-      "integrity": "sha512-Ym4E7g5gX7+mxD0mFM6mYN89eNtB5h+sZ+9S7QZwh930BjIwptNlHwu83QXWlBj9KVDR3zbv5tjlDrlUCj0RAw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-protocol/-/networked-dom-protocol-0.3.0.tgz",
+      "integrity": "sha512-0JftHfVFL5H1GgxL3iJJnmCrrJfhyULcnvuGx4gtLfsjknlN12+eJgtPgZO3+l4rfCz4m3Praj3XfhvDy4uojg=="
     },
     "node_modules/@mml-io/networked-dom-web": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-web/-/networked-dom-web-0.2.0.tgz",
-      "integrity": "sha512-SyFwsg6YQKzq3Kbv0+i4QgNkuQy0ypRq8hY3iR8xYRa25BL0ctaa62UI3VVy97mYT36HQTVuk/TQ1kjynh3jxA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-web/-/networked-dom-web-0.3.0.tgz",
+      "integrity": "sha512-xhVKn/YYH/efkawUR/lpoIMQcB2gVGmBjJaHkWpCpN9puLxFdM7vvT+MNVuVtkkQyynp0G2bw2sBc3HV4G1Xog==",
       "dependencies": {
-        "@mml-io/networked-dom-protocol": "^0.2.0"
+        "@mml-io/networked-dom-protocol": "^0.3.0"
       }
     },
     "node_modules/@mml-io/observable-dom": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom/-/observable-dom-0.2.0.tgz",
-      "integrity": "sha512-YjmOQvL4ansCQkqIR/LDiPpdbUuvWzZysWZY+7T+6BFYY5rJx2alQZJ5IP6YiN2NkIDYHWcjSQvdzzkiN9JVrQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom/-/observable-dom-0.3.0.tgz",
+      "integrity": "sha512-dwjD/Y0ae3whMPtbyNsIRW4PucWZ+1QVnrLyuPWyZmUiIo/D1yBXHFUy7Xv9Z8a5s9mRYVhpyXpk0Zj9R8w0sg==",
       "dependencies": {
-        "@mml-io/observable-dom-common": "^0.2.0",
+        "@mml-io/observable-dom-common": "^0.3.0",
         "jsdom": "22.1.0",
         "node-fetch": "2.6.11"
       }
     },
     "node_modules/@mml-io/observable-dom-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom-common/-/observable-dom-common-0.2.0.tgz",
-      "integrity": "sha512-3x1F1M9nrtJL18PwUIJi7YNbb4xFBl5k5tRDxUFag5c2EP3Kt9HamTiIzcJgdL6o8KveUQTDog+t6z3toWPFbg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom-common/-/observable-dom-common-0.3.0.tgz",
+      "integrity": "sha512-nSDE+NJ8pMCEgBgWdzwzHjfFd/t0c0wmweoZIY/Np+IdApBb3mR/zEtVIiQ8qiWke2VWd6sRusVmJcGMgJ7fNw==",
       "dependencies": {
-        "@mml-io/networked-dom-protocol": "^0.2.0"
+        "@mml-io/networked-dom-protocol": "^0.3.0"
       }
     },
     "node_modules/@mml-io/observable-dom/node_modules/node-fetch": {
@@ -2942,7 +3055,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2983,8 +3095,7 @@
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -3182,8 +3293,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3328,7 +3438,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3507,6 +3616,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3571,7 +3694,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3704,7 +3826,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -3773,8 +3894,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -3837,8 +3957,7 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4264,6 +4383,17 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -4407,8 +4537,7 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4440,6 +4569,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -4553,8 +4690,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -6285,8 +6421,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -6852,8 +6987,7 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "6.1.1",
@@ -7097,7 +7231,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7368,7 +7501,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8707,7 +8839,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -8722,7 +8853,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9082,6 +9212,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9095,7 +9236,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9274,7 +9414,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -9287,7 +9426,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -9299,7 +9437,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -9322,11 +9459,11 @@
       }
     },
     "node_modules/mml-web": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mml-web/-/mml-web-0.2.0.tgz",
-      "integrity": "sha512-V6+wMdNSqOX2E6fPihQIohLC5FmbC5sInYGfGXHhmlOhKqB7vYIm2o8S85XKV4elz3jS21IT+SAk/Kethu5DQw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mml-web/-/mml-web-0.3.0.tgz",
+      "integrity": "sha512-FhNl1iqn3Yhhq0t6EGGl2muDfiNMAxLKptmrJ/vN4RdBXkQRh+5j/pN3g3pJtlly749uQoWQ4ifQZsn1eo92Bg==",
       "dependencies": {
-        "@mml-io/networked-dom-web": "^0.2.0"
+        "@mml-io/networked-dom-web": "^0.3.0"
       },
       "peerDependencies": {
         "three": "*"
@@ -9391,6 +9528,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9418,13 +9560,13 @@
       "dev": true
     },
     "node_modules/networked-dom-server": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/networked-dom-server/-/networked-dom-server-0.2.0.tgz",
-      "integrity": "sha512-HcN1ltb3NnY3ekIJzLg9o3+UIWAHSINRH4qnt1Jvh+aN038FUhP+s9/JYCOtRkexAGbG8bN0fTKp+M00Z4qXxw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/networked-dom-server/-/networked-dom-server-0.3.0.tgz",
+      "integrity": "sha512-sNE7V6AH2vjA0K5fvyGYIbRx630ly83d5GryVQ/Kv0R3BT7PVs4hI8SSVyUWwyDDdBKNKXjfmT3E4WZzKTFq6g==",
       "dependencies": {
-        "@mml-io/networked-dom-document": "^0.2.0",
-        "@mml-io/observable-dom": "^0.2.0",
-        "@mml-io/observable-dom-common": "^0.2.0"
+        "@mml-io/networked-dom-document": "^0.3.0",
+        "@mml-io/observable-dom": "^0.3.0",
+        "@mml-io/observable-dom-common": "^0.3.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -9443,7 +9585,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10236,7 +10377,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -10747,7 +10887,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11557,7 +11696,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11866,7 +12004,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -11881,7 +12018,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -11947,8 +12083,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -12013,8 +12148,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sigstore": {
       "version": "1.7.0",
@@ -12031,6 +12165,35 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -12243,7 +12406,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -12261,7 +12423,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12335,7 +12496,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12499,7 +12659,6 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -12532,7 +12691,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -12544,7 +12702,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13194,8 +13351,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -13393,7 +13549,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -13442,8 +13597,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.1",
@@ -13594,8 +13748,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -13697,7 +13850,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@mml-playground/character-network": "0.0.1",
-        "mml-web": "0.2.0",
+        "mml-web": "0.3.0",
         "postprocessing": "6.32.1",
         "three": "^0.153.0",
         "three-mesh-bvh": "0.6.0"
@@ -13712,12 +13865,13 @@
       "dependencies": {
         "@mml-playground/character-network": "0.0.1",
         "@mml-playground/web": "0.0.1",
+        "canvas": "^2.11.2",
         "chokidar": "^3.5.3",
         "cors": "^2.8.5",
         "express": "4.18.2",
         "express-ws": "5.0.2",
         "http-proxy": "^1.18.1",
-        "networked-dom-server": "0.2.0",
+        "networked-dom-server": "0.3.0",
         "ws": "8.13.0"
       },
       "devDependencies": {
@@ -14501,35 +14655,123 @@
         }
       }
     },
-    "@mml-io/networked-dom-document": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-document/-/networked-dom-document-0.2.0.tgz",
-      "integrity": "sha512-IzRA8r7k3hOYclHk2WK9BR6sN2HBr8BWY4Tmxg8jKBMyvKtlDhwCCb03EG4BrEc8OEFEdTcmZ5e71ecx+loxuw==",
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
       "requires": {
-        "@mml-io/networked-dom-protocol": "^0.2.0",
-        "@mml-io/observable-dom-common": "^0.2.0",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+        },
+        "are-we-there-yet": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "gauge": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+          "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+          "requires": {
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
+            "signal-exit": "^3.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "nopt": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "npmlog": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+          "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+          "requires": {
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "@mml-io/networked-dom-document": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-document/-/networked-dom-document-0.3.0.tgz",
+      "integrity": "sha512-9bi9QZD+SQamzNabUoLWe0bcEMd5zFBb+39nKZb5pnBbGr2SiD5Chb1/YEHF3ltuZ0ht4Jasy/f3ghiT8H80Rw==",
+      "requires": {
+        "@mml-io/networked-dom-protocol": "^0.3.0",
+        "@mml-io/observable-dom-common": "^0.3.0",
         "rfc6902": "git+https://github.com/marcuslongmuir/rfc6902.git#7b81b044d7c2cd36f34f9f30d106e7f5db8a0589"
       }
     },
     "@mml-io/networked-dom-protocol": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-protocol/-/networked-dom-protocol-0.2.0.tgz",
-      "integrity": "sha512-Ym4E7g5gX7+mxD0mFM6mYN89eNtB5h+sZ+9S7QZwh930BjIwptNlHwu83QXWlBj9KVDR3zbv5tjlDrlUCj0RAw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-protocol/-/networked-dom-protocol-0.3.0.tgz",
+      "integrity": "sha512-0JftHfVFL5H1GgxL3iJJnmCrrJfhyULcnvuGx4gtLfsjknlN12+eJgtPgZO3+l4rfCz4m3Praj3XfhvDy4uojg=="
     },
     "@mml-io/networked-dom-web": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-web/-/networked-dom-web-0.2.0.tgz",
-      "integrity": "sha512-SyFwsg6YQKzq3Kbv0+i4QgNkuQy0ypRq8hY3iR8xYRa25BL0ctaa62UI3VVy97mYT36HQTVuk/TQ1kjynh3jxA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/networked-dom-web/-/networked-dom-web-0.3.0.tgz",
+      "integrity": "sha512-xhVKn/YYH/efkawUR/lpoIMQcB2gVGmBjJaHkWpCpN9puLxFdM7vvT+MNVuVtkkQyynp0G2bw2sBc3HV4G1Xog==",
       "requires": {
-        "@mml-io/networked-dom-protocol": "^0.2.0"
+        "@mml-io/networked-dom-protocol": "^0.3.0"
       }
     },
     "@mml-io/observable-dom": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom/-/observable-dom-0.2.0.tgz",
-      "integrity": "sha512-YjmOQvL4ansCQkqIR/LDiPpdbUuvWzZysWZY+7T+6BFYY5rJx2alQZJ5IP6YiN2NkIDYHWcjSQvdzzkiN9JVrQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom/-/observable-dom-0.3.0.tgz",
+      "integrity": "sha512-dwjD/Y0ae3whMPtbyNsIRW4PucWZ+1QVnrLyuPWyZmUiIo/D1yBXHFUy7Xv9Z8a5s9mRYVhpyXpk0Zj9R8w0sg==",
       "requires": {
-        "@mml-io/observable-dom-common": "^0.2.0",
+        "@mml-io/observable-dom-common": "^0.3.0",
         "jsdom": "22.1.0",
         "node-fetch": "2.6.11"
       },
@@ -14545,11 +14787,11 @@
       }
     },
     "@mml-io/observable-dom-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom-common/-/observable-dom-common-0.2.0.tgz",
-      "integrity": "sha512-3x1F1M9nrtJL18PwUIJi7YNbb4xFBl5k5tRDxUFag5c2EP3Kt9HamTiIzcJgdL6o8KveUQTDog+t6z3toWPFbg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mml-io/observable-dom-common/-/observable-dom-common-0.3.0.tgz",
+      "integrity": "sha512-nSDE+NJ8pMCEgBgWdzwzHjfFd/t0c0wmweoZIY/Np+IdApBb3mR/zEtVIiQ8qiWke2VWd6sRusVmJcGMgJ7fNw==",
       "requires": {
-        "@mml-io/networked-dom-protocol": "^0.2.0"
+        "@mml-io/networked-dom-protocol": "^0.3.0"
       }
     },
     "@mml-playground/character-network": {
@@ -14569,7 +14811,7 @@
       "requires": {
         "@mml-playground/character-network": "0.0.1",
         "@types/three": "^0.152.1",
-        "mml-web": "0.2.0",
+        "mml-web": "0.3.0",
         "postprocessing": "6.32.1",
         "three": "^0.153.0",
         "three-mesh-bvh": "0.6.0"
@@ -14585,12 +14827,13 @@
         "@types/express-ws": "^3.0.1",
         "@types/http-proxy": "^1.17.11",
         "@types/node": "^20.3.0",
+        "canvas": "^2.11.2",
         "chokidar": "^3.5.3",
         "cors": "^2.8.5",
         "express": "4.18.2",
         "express-ws": "5.0.2",
         "http-proxy": "^1.18.1",
-        "networked-dom-server": "0.2.0",
+        "networked-dom-server": "0.3.0",
         "nodemon": "^2.0.22",
         "ws": "8.13.0"
       }
@@ -15896,8 +16139,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -15926,8 +16168,7 @@
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
     "are-we-there-yet": {
       "version": "3.0.1",
@@ -16077,8 +16318,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -16188,7 +16428,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16316,6 +16555,16 @@
         "quick-lru": "^4.0.1"
       }
     },
+    "canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -16361,8 +16610,7 @@
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -16463,8 +16711,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "columnify": {
       "version": "1.6.0",
@@ -16520,8 +16767,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -16571,8 +16817,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -16889,6 +17134,14 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -16998,8 +17251,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -17022,6 +17274,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
       "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
       "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
     },
     "diff": {
       "version": "4.0.2",
@@ -17106,8 +17363,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -18332,8 +18588,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -18748,8 +19003,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "hosted-git-info": {
       "version": "6.1.1",
@@ -18927,7 +19181,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -19127,8 +19380,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -20142,7 +20394,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -20150,8 +20401,7 @@
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -20425,6 +20675,11 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -20435,7 +20690,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -20580,7 +20834,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -20590,7 +20843,6 @@
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
           "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -20600,8 +20852,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mkdirp-infer-owner": {
       "version": "2.0.0",
@@ -20615,11 +20866,11 @@
       }
     },
     "mml-web": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mml-web/-/mml-web-0.2.0.tgz",
-      "integrity": "sha512-V6+wMdNSqOX2E6fPihQIohLC5FmbC5sInYGfGXHhmlOhKqB7vYIm2o8S85XKV4elz3jS21IT+SAk/Kethu5DQw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mml-web/-/mml-web-0.3.0.tgz",
+      "integrity": "sha512-FhNl1iqn3Yhhq0t6EGGl2muDfiNMAxLKptmrJ/vN4RdBXkQRh+5j/pN3g3pJtlly749uQoWQ4ifQZsn1eo92Bg==",
       "requires": {
-        "@mml-io/networked-dom-web": "^0.2.0"
+        "@mml-io/networked-dom-web": "^0.3.0"
       }
     },
     "modify-values": {
@@ -20671,6 +20922,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -20695,13 +20951,13 @@
       "dev": true
     },
     "networked-dom-server": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/networked-dom-server/-/networked-dom-server-0.2.0.tgz",
-      "integrity": "sha512-HcN1ltb3NnY3ekIJzLg9o3+UIWAHSINRH4qnt1Jvh+aN038FUhP+s9/JYCOtRkexAGbG8bN0fTKp+M00Z4qXxw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/networked-dom-server/-/networked-dom-server-0.3.0.tgz",
+      "integrity": "sha512-sNE7V6AH2vjA0K5fvyGYIbRx630ly83d5GryVQ/Kv0R3BT7PVs4hI8SSVyUWwyDDdBKNKXjfmT3E4WZzKTFq6g==",
       "requires": {
-        "@mml-io/networked-dom-document": "^0.2.0",
-        "@mml-io/observable-dom": "^0.2.0",
-        "@mml-io/observable-dom-common": "^0.2.0"
+        "@mml-io/networked-dom-document": "^0.3.0",
+        "@mml-io/observable-dom": "^0.3.0",
+        "@mml-io/observable-dom-common": "^0.3.0"
       }
     },
     "node-addon-api": {
@@ -20720,7 +20976,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -21312,7 +21567,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -21687,8 +21941,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -22279,7 +22532,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -22488,7 +22740,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -22497,7 +22748,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -22560,8 +22810,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -22611,8 +22860,7 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sigstore": {
       "version": "1.7.0",
@@ -22623,6 +22871,21 @@
         "@sigstore/protobuf-specs": "^0.1.0",
         "@sigstore/tuf": "^1.0.1",
         "make-fetch-happen": "^11.0.1"
+      }
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "simple-update-notifier": {
@@ -22798,7 +23061,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -22813,7 +23075,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -22868,7 +23129,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -22981,7 +23241,6 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -22995,7 +23254,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
           "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -23004,7 +23262,6 @@
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
           "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -23499,8 +23756,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -23658,7 +23914,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -23694,8 +23949,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "4.0.1",
@@ -23806,8 +24060,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@mml-playground/character-network": "0.0.1",
-    "mml-web": "0.2.0",
+    "mml-web": "0.3.0",
     "three": "^0.153.0",
     "postprocessing": "6.32.1",
     "three-mesh-bvh": "0.6.0"

--- a/packages/core/src/mml/CoreMMLScene.ts
+++ b/packages/core/src/mml/CoreMMLScene.ts
@@ -9,6 +9,7 @@ import {
   registerCustomElementsToWindow,
   setGlobalMScene,
   PositionAndRotation,
+  MElement,
 } from "mml-web";
 import { AudioListener, Group, Object3D, PerspectiveCamera, Scene, WebGLRenderer } from "three";
 
@@ -44,8 +45,8 @@ export class CoreMMLScene {
       getThreeScene: () => this.scene,
       getRootContainer: () => this.group,
       getCamera: () => this.camera,
-      addCollider: (object: Object3D) => {
-        this.collisionsManager.addMeshesGroup(object as Group);
+      addCollider: (object: Object3D, mElement: MElement) => {
+        this.collisionsManager.addMeshesGroup(object as Group, mElement);
       },
       updateCollider: (object: Object3D) => {
         this.collisionsManager.updateMeshesGroup(object as Group);

--- a/packages/server/examples/collision-events.html
+++ b/packages/server/examples/collision-events.html
@@ -1,0 +1,170 @@
+<m-cube y="1" color="red" id="collision-cube" collision-interval="100">
+  <m-cube y="1" z="-1" collision-interval="100"></m-cube>
+</m-cube>
+<m-cube y="0.8" ry="30" height="0.1" width="6" depth="6" color="orange" id="collision-ground" collision-interval="100">
+  <m-image id="canvas-view" rx="90" y="0.5" collide="false" width="6" height="6"></m-image>
+  <m-label id="standing-label" content="Standing: 0" rx="-90" z="2" y="0.08" width="3" font-size="40"></m-label>
+</m-cube>
+
+<m-group id="stairs" ry="180" x="-5.5" z="3"></m-group>
+
+<script>
+  const stairs = document.getElementById("stairs");
+
+  function getHexForCurrentTime(lightness) {
+    const hue = ((Date.now() % 2000)/2000) * 360;
+    const saturation = 1.0;
+    const alpha = saturation * Math.min(lightness, 1 - lightness);
+    const getF = number => {
+      const k = (number + hue / 30) % 12;
+      return lightness - alpha * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)))
+    };
+    const red = Math.round(255 * getF(0));
+    const green = Math.round(255 * getF(8));
+    const blue = Math.round(255 * getF(4));
+    const hex = "#"+(red.toString(16).padStart(2, "0"))+(green.toString(16).padStart(2, "0"))+(blue.toString(16).padStart(2, "0"));
+    return hex;
+  }
+
+  for (let i = 0; i < 15; i++) {
+    const stair = document.createElement("m-cube");
+    stair.setAttribute("z", i * 0.5);
+    stair.setAttribute("y", i * 0.2);
+    stair.setAttribute("width", 2);
+    stair.setAttribute("height", 0.2);
+    stair.setAttribute("depth", 0.5);
+    stair.setAttribute("color", "blue");
+    stair.setAttribute("collision-interval","1000");
+    stair.addEventListener("collisionstart", () => {
+      stair.setAttribute("color", "white");
+    });
+    stair.addEventListener("collisionend", () => {
+      stair.setAttribute("color", getHexForCurrentTime(0.5));
+    });
+    stairs.append(stair);
+  }
+
+  const collisionCube = document.getElementById("collision-cube");
+  let collidingCubeUsers = new Set();
+  function updateCollidingCubeState() {
+    if (collidingCubeUsers.size === 0) {
+      collisionCube.setAttribute("color", "red");
+    } else {
+      collisionCube.setAttribute("color", "green");
+    }
+  }
+  updateCollidingCubeState();
+  collisionCube.addEventListener("collisionstart", (event) => {
+    const { connectionId } = event.detail;
+    collidingCubeUsers.add(connectionId);
+    updateCollidingCubeState();
+  });
+  collisionCube.addEventListener("collisionend", (event) => {
+    const { connectionId } = event.detail;
+    collidingCubeUsers.delete(connectionId);
+    updateCollidingCubeState();
+  });
+  window.addEventListener("disconnected", (event) => {
+    const { connectionId } = event.detail;
+    collidingCubeUsers.delete(connectionId);
+    updateCollidingCubeState();
+  });
+
+  const collisionGround = document.getElementById("collision-ground");
+  const standingLabel = document.getElementById("standing-label");
+  const connectedUsers = new Map();
+  function updateCollidingGroundState() {
+    if (connectedUsers.size === 0) {
+      collisionGround.setAttribute("color", "orange");
+    } else {
+      const floorColor = `#${Math.floor(0x444466 + Math.min(6, connectedUsers.size) * 0x000019).toString(16)}`;
+      collisionGround.setAttribute("color", floorColor);
+    }
+    standingLabel.setAttribute("content", `Standing: ${connectedUsers.size}`);
+  }
+  collisionGround.addEventListener("collisionstart", (event) => {
+    const { connectionId } = event.detail;
+    getOrCreateUser(connectionId, event.detail.position, event.detail.rotation);
+    drawState();
+    updateCollidingGroundState();
+  });
+  collisionGround.addEventListener("collisionmove", (event) => {
+    const { connectionId } = event.detail;
+    getOrCreateUser(connectionId, event.detail.position, event.detail.rotation);
+    drawState();
+    updateCollidingGroundState();
+  });
+  collisionGround.addEventListener("collisionend", (event) => {
+    const { connectionId } = event.detail;
+    clearUser(connectionId);
+    drawState();
+    updateCollidingGroundState();
+  });
+  window.addEventListener("disconnected", (event) => {
+    const { connectionId } = event.detail;
+    clearUser(connectionId);
+    drawState();
+    updateCollidingGroundState();
+  });
+
+  function getOrCreateUser(connectionId, position, rotation) {
+    const user = connectedUsers.get(connectionId);
+    if (user) {
+      user.position = position;
+      user.rotation = rotation;
+      return user;
+    }
+    const newUser = {
+      position,
+      rotation,
+    };
+    connectedUsers.set(connectionId, newUser);
+    return newUser;
+  }
+
+  function clearUser(connectionId) {
+    const user = connectedUsers.get(connectionId);
+    if (!user) return;
+    connectedUsers.delete(connectionId);
+  }
+
+  window.addEventListener("disconnected", (event) => {
+    const { connectionId } = event.detail;
+    clearUser(connectionId);
+    drawState();
+  });
+
+  let rotatingFloorRotation = 0;
+  setInterval(() => {
+    rotatingFloorRotation += 1;
+    collisionGround.setAttribute("ry", (Date.now() / 100) % 360);
+  }, 100);
+
+  const canvasView = document.getElementById("canvas-view");
+  const canvas = document.createElement("canvas");
+  const width = 256;
+  const height = width;
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+  const pointDrawSize = 64;
+  const halfPointDrawSize = pointDrawSize / 2;
+  canvas.width = width;
+  canvas.height = height;
+  const scale = width/parseFloat(canvasView.getAttribute("width"));
+  const ctx = canvas.getContext("2d");
+  function drawState() {
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
+    ctx.fillRect(0, 0, halfWidth, halfHeight);
+    ctx.fillStyle = "orange";
+    ctx.fillRect(halfWidth, halfHeight, halfWidth, halfHeight);
+    ctx.fillStyle = "green";
+    for (const [connectionId, user] of connectedUsers) {
+      ctx.fillRect(halfWidth + user.position.x * scale - halfPointDrawSize, halfHeight - user.position.z * scale - halfPointDrawSize, pointDrawSize, pointDrawSize);
+    }
+    ctx.strokeRect(0, 0, width, height);
+    const dataUri = canvas.toDataURL("image/png");
+    canvasView.setAttribute("src", dataUri);
+  }
+  drawState();
+</script>

--- a/packages/server/examples/position-probe.html
+++ b/packages/server/examples/position-probe.html
@@ -1,0 +1,104 @@
+<m-group x="3" ry="30" y="4">
+  <m-position-probe range="7" debug="true" id="my-probe" interval="100"></m-position-probe>
+  <m-image id="canvas-view" rx="90" y="-3.5" collide="false" width="14" height="14"></m-image>
+  <m-group id="user-presence-holder"></m-group>
+</m-group>
+
+<script>
+  const connectedUsers = new Map();
+  const userPresenceHolder = document.getElementById("user-presence-holder");
+  const positionProbe = document.getElementById("my-probe");
+
+  function getOrCreateUser(connectionId, position, rotation) {
+    const user = connectedUsers.get(connectionId);
+    if (user) {
+      user.position = position;
+      user.rotation = rotation;
+      return user;
+    }
+    const userCube = document.createElement("m-cube");
+    userCube.setAttribute("collide", false);
+    userCube.setAttribute("width", 0.25);
+    userCube.setAttribute("height", 0.25);
+    userCube.setAttribute("depth", 0.25);
+    userCube.setAttribute("color", `#${Math.floor(Math.random() * 0xffffff).toString(16)}`);
+    userPresenceHolder.append(userCube);
+    const newUser = {
+      cube: userCube,
+      position,
+      rotation,
+    };
+    connectedUsers.set(connectionId, newUser);
+    return newUser;
+  }
+
+  function clearUser(connectionId) {
+    const user = connectedUsers.get(connectionId);
+    if (!user) return;
+    user.cube.remove();
+    connectedUsers.delete(connectionId);
+  }
+
+  function setCubePosition(connectionId, position, rotation) {
+    const user = getOrCreateUser(connectionId, position, rotation);
+    user.cube.setAttribute("x", position.x);
+    user.cube.setAttribute("y", position.y + 2);
+    user.cube.setAttribute("z", position.z);
+    user.cube.setAttribute("rx", rotation.x);
+    user.cube.setAttribute("ry", rotation.y);
+    user.cube.setAttribute("rz", rotation.z);
+  }
+
+  window.addEventListener("disconnected", (event) => {
+    const { connectionId } = event.detail;
+    clearUser(connectionId);
+    drawState();
+  });
+
+  positionProbe.addEventListener("positionenter", (event) => {
+    const { connectionId, elementRelative, documentRelative } = event.detail;
+    setCubePosition(connectionId, elementRelative.position, elementRelative.rotation);
+    drawState();
+  });
+
+  positionProbe.addEventListener("positionmove", (event) => {
+    const { connectionId, elementRelative, documentRelative } = event.detail;
+    /*
+       It's possible to receive an update without an explicit enter event if this user is already in the range of
+       this element when the document is reloaded. In this case, we need to create the user as if this is an
+       enter event.
+      */
+    setCubePosition(connectionId, elementRelative.position, elementRelative.rotation);
+    drawState();
+  });
+
+  positionProbe.addEventListener("positionleave", (event) => {
+    const { connectionId } = event.detail;
+    clearUser(connectionId);
+    drawState();
+  });
+
+  const canvasView = document.getElementById("canvas-view");
+  const canvas = document.createElement("canvas");
+  canvas.width = 512;
+  canvas.height = 512;
+  const scale = 512/parseFloat(canvasView.getAttribute("width"));
+  const pointDrawSize = 64;
+  const halfPointDrawSize = pointDrawSize / 2;
+  const ctx = canvas.getContext("2d");
+  function drawState() {
+    ctx.clearRect(0, 0, 512, 512);
+    ctx.fillStyle = "red";
+    ctx.fillRect(128, 128, 128, 128);
+    ctx.fillStyle = "orange";
+    ctx.fillRect(256, 256, 128, 128);
+    ctx.fillStyle = "green";
+    for (const [connectionId, user] of connectedUsers) {
+      ctx.fillRect(256 + user.position.x * scale - halfPointDrawSize, 256 - user.position.z * scale - halfPointDrawSize, pointDrawSize, pointDrawSize);
+    }
+    ctx.strokeRect(0, 0, 512, 512);
+    const dataUri = canvas.toDataURL("image/png");
+    canvasView.setAttribute("src", dataUri);
+  }
+  drawState();
+</script>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,8 +18,9 @@
   "dependencies": {
     "@mml-playground/character-network": "0.0.1",
     "@mml-playground/web": "0.0.1",
-    "networked-dom-server": "0.2.0",
+    "networked-dom-server": "0.3.0",
     "chokidar": "^3.5.3",
+    "canvas": "^2.11.2",
     "express": "4.18.2",
     "express-ws": "5.0.2",
     "cors": "^2.8.5",

--- a/packages/server/playground.html
+++ b/packages/server/playground.html
@@ -20,6 +20,18 @@
 
       const DEMO_SLOTS = [
         {
+          x: -34,
+          z: (SLOT_DEPTH + SPACE_BETWEEN_SLOTS) * 0,
+          documentUrl: `${window.params.EXAMPLES_HOST_URL}/collision-events.html`,
+          title: "collision events experiment",
+        },
+        {
+          x: -34,
+          z: (SLOT_DEPTH + SPACE_BETWEEN_SLOTS) * 1,
+          documentUrl: `${window.params.EXAMPLES_HOST_URL}/position-probe.html`,
+          title: "m-position-probe experiment",
+        },
+        {
           x: -20,
           z: (SLOT_DEPTH + SPACE_BETWEEN_SLOTS) * 0,
           documentUrl: `${window.params.EXAMPLES_HOST_URL}/duck.html`,

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,6 +9,7 @@ import {
   KeyInputManager,
   RunTimeManager,
 } from "@mml-playground/core";
+import { MMLCollisionTrigger } from "mml-web";
 import { AudioListener, Fog, Group, PerspectiveCamera, Scene } from "three";
 
 import { Environment } from "./Environment";
@@ -28,6 +29,7 @@ export class App {
   private readonly cameraManager: CameraManager;
   private readonly collisionsManager: CollisionsManager;
   private readonly networkClient: CharacterNetworkClient;
+  private readonly collisionTrigger: MMLCollisionTrigger;
 
   private readonly modelsPath: string = "/web-client/assets/models";
   private readonly characterDescription: CharacterDescription | null = null;
@@ -46,7 +48,8 @@ export class App {
     this.camera.add(this.audioListener);
     this.composer = new Composer(this.scene, this.camera);
     this.networkClient = new CharacterNetworkClient();
-    this.collisionsManager = new CollisionsManager(this.scene);
+    this.collisionTrigger = MMLCollisionTrigger.init();
+    this.collisionsManager = new CollisionsManager(this.scene, this.collisionTrigger);
     this.characterManager = new CharacterManager(
       this.collisionsManager,
       this.cameraManager,


### PR DESCRIPTION
Resolves #24

This PR:
* Upgrades to MML `v0.3.0`
* Uses the `MMLCollisionTrigger` class provided by the `mml-web@0.3.0` library to emit events to MML elements when the local user's avatar collides with them. Docs for the events can be found under the `collideable` attribute group on supported elements: e.g. https://mml.io/docs/reference/elements/m-cube (or see next point)
* Adds two examples to the playground. One that uses collision events to react to stairs being stood on and a rotating plate that draws contact points to a texture using `canvas2d`, the other is a related example for `m-position-probe` that is useful to see in combination with collision events.

![image](https://github.com/mml-io/mml-playground/assets/669895/9607e468-c4d2-4ab6-b991-193daf8bf117)

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR fulfill the following requirements?**

- [x] The title references the corresponding issue # (if relevant)
