### PR TITLE
fixes input manager to account for clicks out of the document

### DIFF
--- a/packages/core/src/input/KeyInputManager.ts
+++ b/packages/core/src/input/KeyInputManager.ts
@@ -8,7 +8,7 @@ export class KeyInputManager {
   }
 
   private handleUnfocus(_event: FocusEvent): void {
-    this.keys = new Map<string, boolean>();
+    this.keys.clear();
   }
 
   private onKeyDown(event: KeyboardEvent): void {

--- a/packages/core/src/input/KeyInputManager.ts
+++ b/packages/core/src/input/KeyInputManager.ts
@@ -4,6 +4,11 @@ export class KeyInputManager {
   constructor() {
     document.addEventListener("keydown", this.onKeyDown.bind(this));
     document.addEventListener("keyup", this.onKeyUp.bind(this));
+    window.addEventListener("blur", this.handleUnfocus.bind(this));
+  }
+
+  private handleUnfocus(_event: FocusEvent): void {
+    this.keys = new Map<string, boolean>();
   }
 
   private onKeyDown(event: KeyboardEvent): void {
@@ -33,5 +38,6 @@ export class KeyInputManager {
   public dispose() {
     document.removeEventListener("keydown", this.onKeyDown.bind(this));
     document.removeEventListener("keyup", this.onKeyDown.bind(this));
+    window.removeEventListener("blur", this.handleUnfocus.bind(this));
   }
 }


### PR DESCRIPTION
This PR fixes the input manager to account for clicks outside the document while the player moves. This will prevent the player from keeping moving in its current direction, even after the movement key is released, due to clicks out of the document.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
